### PR TITLE
chore(linter): enable usetesting linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,7 @@ linters:
     - unconvert
     - unparam
     - usestdlibvars
+    - usetesting
     - varnamelen
     - wastedassign
     - whitespace
@@ -181,10 +182,6 @@ linters:
           - maintidx
           - nestif
         path: _test.go
-      - linters:
-          - gosmopolitan
-          - misspell
-        path: util/bip39/wordlists/
       - path: (.+)\.go$
         text: 'shadow: declaration of "err" shadows'
       - path: (.+)\.go$

--- a/www/grpc/server_test.go
+++ b/www/grpc/server_test.go
@@ -3,7 +3,6 @@ package grpc
 import (
 	"context"
 	"net"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -55,10 +54,7 @@ func setup(t *testing.T, conf *Config) *testData {
 	ts := testsuite.NewTestSuite(t)
 
 	// for saving test wallets in temp directory
-	err := os.Chdir(util.TempDirPath())
-	if err != nil {
-		panic(err)
-	}
+	t.Chdir(util.TempDirPath())
 
 	const bufSize = 1024 * 1024
 


### PR DESCRIPTION
## Description

> This PR add usetesting in linter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded linting coverage by enabling additional checks and removing prior exclusions, improving consistency and catching more issues across the codebase.

* **Tests**
  * Simplified test setup by using the testing framework’s working-directory helper, reducing boilerplate and improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->