### PR TITLE
feat(wallet): implement automatic address recovery on recover wallet

### DIFF
--- a/cmd/wallet/recover.go
+++ b/cmd/wallet/recover.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"os"
 	"os/signal"
 	"syscall"
 
@@ -40,14 +39,8 @@ func buildRecoverCmd(parentCmd *cobra.Command) {
 		wlt, err := wallet.Create(*pathOpt, mnemonic, *passOpt, chainType)
 		cmd.FatalErrorCheck(err)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		sigChan := make(chan os.Signal, 1)
-		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-
-		go func() {
-			<-sigChan
-			cancel()
-		}()
+		ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
 
 		cmd.PrintInfoMsgf("Recovering wallet addresses (Ctrl+C to abort)...")
 		cmd.PrintLine()


### PR DESCRIPTION
## Description

> This PR add automatic address recovery on `recover` command of aerium-wallet.

```bash
Recovering wallet addresses (Ctrl+C to abort)...

1. tae1r3jq9c2mstluhunh366tm80ll9t4mw9g43c0rws

Saving wallet..
```

## Related Issue

Fixes #7 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Wallet recovery can now be safely canceled with Ctrl+C, interrupting the process without losing progress.
  - Added live progress feedback while recovering addresses.

- Improvements
  - Clearer messaging distinguishes between user-canceled recovery and actual errors.
  - Wallet changes are saved before exit, even if the recovery is canceled or fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->