### PR TITLE
feat(releaser): add configuration files for release drafter setup

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -1,0 +1,30 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+exclude-labels:
+  - 'skip-changelog'
+version-resolver:
+  minor:
+    labels:
+      - 'breaking-change'
+  default: patch
+categories:
+  - title: '⚠️ Breaking changes'
+    label: 'breaking-change'
+  - title: '🚀 Enhancements'
+    label: 'enhancement'
+  - title: '🐛 Bug Fixes'
+    label: 'bug'
+  - title: '⚙️ Maintenance/misc'
+    label:
+      - 'dependencies'
+      - 'maintenance'
+      - 'documentation'
+template: |
+  $CHANGES
+
+  Thanks again to $CONTRIBUTORS! 🎉
+no-changes-template: 'Changes are coming soon 😎'
+sort-direction: 'ascending'
+replacers:
+  - search: '/(?:and )?@meili-bot,?/g'
+    replace: ''

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-draft-template.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

This pull request introduces automated release drafting to the project by adding configuration and workflow files for Release Drafter. The main changes are the addition of a release template that categorizes changes and a GitHub Actions workflow to keep the release draft updated on every push to `main`.

Release automation setup:

* Added `.github/release-draft-template.yml` to define the release note format, categorize PRs by label (breaking changes, enhancements, bug fixes, maintenance), and customize versioning and changelog output.
* Added `.github/workflows/release-drafter.yml` to set up a GitHub Actions workflow that runs Release Drafter on every push to `main`, updating the release draft automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Set up automated release notes generation for future releases.
  * Release drafts now categorize updates (breaking changes, enhancements, bug fixes, maintenance/docs), infer version bumps, sort entries ascending, and include a clear “no changes” message.
  * Automated drafts use a standardized template for consistent, readable changelogs and remove bot mentions for cleaner output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->