### PR TITLE
feat(release-drafter): update version resolver labels in release

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -3,9 +3,12 @@ tag-template: 'v$RESOLVED_VERSION'
 exclude-labels:
   - 'skip-changelog'
 version-resolver:
-  minor:
+  major:
     labels:
       - 'breaking-change'
+  minor:
+    labels:
+      - 'enhancement'
   default: patch
 categories:
   - title: '⚠️ Breaking changes'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Adjusted automated release drafting rules: “breaking-change” now maps to a major version bump; added a minor bump mapping via “enhancement”; default remains patch. Category groupings are unchanged. Affects version numbers shown in future releases only. No changes to application functionality or UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->