### PR TITLE
feat(http): add origins support from config for gRPC-gateway HTTP-API (CORS)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -152,6 +152,7 @@ func DefaultConfigMainnet() *Config {
 	conf.HTTP.Enable = false
 	conf.HTTP.Listen = "127.0.0.1:8080"
 	conf.HTTP.BasePath = "/http"
+	conf.HTTP.Origins = []string{}
 	conf.JSONRPC.Enable = false
 	conf.JSONRPC.Listen = "127.0.0.1:8545"
 	conf.JSONRPC.Origins = []string{}
@@ -176,6 +177,7 @@ func DefaultConfigTestnet() *Config {
 	conf.HTTP.Enable = true
 	conf.HTTP.Listen = "[::]:8080"
 	conf.HTTP.BasePath = "/http"
+	conf.HTTP.Origins = []string{}
 	conf.JSONRPC.Enable = true
 	conf.JSONRPC.Listen = "[::]:8545"
 	conf.JSONRPC.Origins = []string{}
@@ -204,6 +206,7 @@ func DefaultConfigLocalnet() *Config {
 	conf.HTML.EnablePprof = true
 	conf.HTTP.Enable = true
 	conf.HTTP.Listen = "[::]:8080"
+	conf.HTTP.Origins = []string{"*"}
 	conf.JSONRPC.Enable = true
 	conf.JSONRPC.Listen = "[::]:8545"
 	conf.JSONRPC.Origins = []string{"*"}

--- a/config/example_config.toml
+++ b/config/example_config.toml
@@ -223,9 +223,16 @@
   base_path = '/http'
 
   # `enable_cors` indicates whether Cross-Origin Resource Sharing (CORS)
-  # should be enabled.
+  # if `enable_cors` is true and `origins` is empty, CORS is enabled for all origins.
   # Default is `false`.
   enable_cors = false
+
+  # `origins` specifies the allowed CORS origins for the HTTP-API server.
+  # This controls which domains can make requests to the HTTP-API from a browser.
+  # Only the specified origins will be allowed. If not set or left empty, CORS is disabled by default.
+  # Example: origins = ["wallet.aerium.app", "*"]
+  origins = []
+
 
 # `html` contains configuration for the HTML server.
 # HTML server is mostly used for debugging and testing purposes.

--- a/www/http/config.go
+++ b/www/http/config.go
@@ -6,10 +6,11 @@ import (
 )
 
 type Config struct {
-	Enable     bool   `toml:"enable"`
-	Listen     string `toml:"listen"`
-	BasePath   string `toml:"base_path"`
-	EnableCORS bool   `toml:"enable_cors"`
+	Enable     bool     `toml:"enable"`
+	Listen     string   `toml:"listen"`
+	BasePath   string   `toml:"base_path"`
+	EnableCORS bool     `toml:"enable_cors"`
+	Origins    []string `toml:"origins"`
 }
 
 func DefaultConfig() *Config {


### PR DESCRIPTION
## Description

This PR introduces origins CORS for HTTP as per the lines of JSONRPC

## Related Feature

Feature #36  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CORS configuration now supports explicit origin specifications for each network environment, with network-specific defaults (unrestricted for local networks, restricted for mainnet and testnet).

* **Chores**
  * Updated configuration documentation to include new CORS origins option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->