### PR TITLE
feat(releaser): create RPM package workflow (amd64 & aarch64)

### DIFF
--- a/.github/releasers/releaser_cli_centos.sh
+++ b/.github/releasers/releaser_cli_centos.sh
@@ -3,7 +3,7 @@
 set -e
 
 ROOT_DIR="$(pwd)"
-VERSION="$(echo `git -C ${ROOT_DIR} describe --abbrev=0 --tags` | sed 's/^.//')" # "v1.2.3" -> "1.2.3"
+VERSION="$(git -C ${ROOT_DIR} describe --abbrev=0 --tags | sed 's/^v//')" # "v1.2.3" -> "1.2.3"
 BUILD_DIR="${ROOT_DIR}/build"
 PACKAGE_NAME="aerium-cli_${VERSION}"
 PACKAGE_DIR="${ROOT_DIR}/${PACKAGE_NAME}"
@@ -13,7 +13,7 @@ PACKAGE_DIR="${ROOT_DIR}/${PACKAGE_NAME}"
 MAINTAINER="Aerium Developers <info@aerium.network>"
 LICENSE="MIT"
 DESC="Aerium Command-Line Tools (daemon, wallet, shell)"
-URL=$(echo `git remote show origin | grep "Fetch URL"` | awk '{printf $3}')
+URL=$(git remote get-url origin)
 CATEGORY="Applications/Financial"
 
 # Check the architecture

--- a/.github/releasers/releaser_cli_centos.sh
+++ b/.github/releasers/releaser_cli_centos.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e
+
+ROOT_DIR="$(pwd)"
+VERSION="$(echo `git -C ${ROOT_DIR} describe --abbrev=0 --tags` | sed 's/^.//')" # "v1.2.3" -> "1.2.3"
+BUILD_DIR="${ROOT_DIR}/build"
+PACKAGE_NAME="aerium-cli_${VERSION}"
+PACKAGE_DIR="${ROOT_DIR}/${PACKAGE_NAME}"
+
+
+# RPM specific metadata
+MAINTAINER="Aerium Developers <info@aerium.network>"
+LICENSE="MIT"
+DESC="Aerium Command-Line Tools (daemon, wallet, shell)"
+URL=$(echo `git remote show origin | grep "Fetch URL"` | awk '{printf $3}')
+CATEGORY="Applications/Financial"
+
+# Check the architecture
+ARC="$(uname -m)"
+
+mkdir -p ${PACKAGE_DIR}
+
+echo "Building the CLI binaries for CentOS ${ARC} architecture"
+
+cd ${ROOT_DIR}
+CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/aerium-daemon ./cmd/daemon
+CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/aerium-wallet ./cmd/wallet
+CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/aerium-shell ./cmd/shell
+
+
+echo "Checking whether FPM is installed"
+fpm -v
+
+echo "Building RPM package"
+
+fpm -s dir -t rpm \
+	-n "aerium-cli" \
+	-v "${VERSION}" \
+	-a "${ARC}" \
+	--license "${LICENSE}" \
+	--maintainer "${MAINTAINER}" \
+	--description "${DESC}" \
+	--url "${URL}" \
+	--category "${CATEGORY}" \
+	--rpm-os linux \
+	"${BUILD_DIR}/aerium-daemon"=/usr/local/bin/aerium-daemon \
+	"${BUILD_DIR}/aerium-shell"=/usr/local/bin/aerium-shell \
+	"${BUILD_DIR}/aerium-wallet"=/usr/local/bin/aerium-wallet
+
+echo "RPM package built successfully for ${ARC} architecture"
+

--- a/.github/releasers/releaser_gui_centos.sh
+++ b/.github/releasers/releaser_gui_centos.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+ROOT_DIR="$(pwd)"
+VERSION="$(echo `git -C ${ROOT_DIR} describe --abbrev=0 --tags` | sed 's/^.//')" # "v1.2.3" -> "1.2.3"
+BUILD_DIR="${ROOT_DIR}/build"
+PACKAGE_NAME="aerium-gui_${VERSION}"
+PACKAGE_DIR="${ROOT_DIR}/${PACKAGE_NAME}"
+
+
+# RPM specific metadata
+MAINTAINER="Aerium Developers <info@aerium.network>"
+LICENSE="MIT"
+DESC="Aerium Desktop Wallet (GUI + CLI components)"
+URL=$(echo `git remote show origin | grep "Fetch URL"` | awk '{printf $3}')
+CATEGORY="User Interface/Desktops"
+
+# Check the architecture
+ARC="$(uname -m)"
+
+mkdir -p ${PACKAGE_DIR}
+
+echo "Building the GUI binaries for CentOS ${ARC} architecture"
+
+cd ${ROOT_DIR}
+go build -ldflags "-s -w" -trimpath -tags gtk -o ${BUILD_DIR}/aerium-gui ./cmd/gtk
+
+
+echo "Checking whether FPM is installed"
+fpm -v
+
+echo "Building RPM package"
+
+fpm -s dir -t rpm \
+	-n "aerium-gui" \
+	-v "${VERSION}" \
+	-a "${ARC}" \
+	--license "${LICENSE}" \
+	--maintainer "${MAINTAINER}" \
+	--description "${DESC}" \
+	--conflicts aerium-cli \
+	--replaces aerium-cli \
+	--provides aerium-cli \
+	--url "${URL}" \
+	--category "${CATEGORY}" \
+	--rpm-os linux \
+	"${BUILD_DIR}/aerium-gui"=/usr/local/bin/aerium-gui \
+	"${ROOT_DIR}/.github/releasers/linux/aerium-gui.desktop"=/usr/share/applications/aerium-gui.desktop \
+	"${ROOT_DIR}/cmd/gtk/assets/images/logo.png"=/usr/share/icons/hicolor/256x256/apps/aerium.png
+
+echo "RPM package built successfully for ${ARC} architecture"
+

--- a/.github/releasers/releaser_gui_centos.sh
+++ b/.github/releasers/releaser_gui_centos.sh
@@ -17,13 +17,16 @@ URL=$(echo `git remote show origin | grep "Fetch URL"` | awk '{printf $3}')
 CATEGORY="User Interface/Desktops"
 
 # Check the architecture
-ARC="$(uname -m)"
+ARC="aarch64"
 
 mkdir -p ${PACKAGE_DIR}
 
 echo "Building the GUI binaries for CentOS ${ARC} architecture"
 
 cd ${ROOT_DIR}
+CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/aerium-daemon ./cmd/daemon
+CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/aerium-wallet ./cmd/wallet
+CGO_ENABLED=0 go build -ldflags "-s -w" -trimpath -o ${BUILD_DIR}/aerium-shell ./cmd/shell
 go build -ldflags "-s -w" -trimpath -tags gtk -o ${BUILD_DIR}/aerium-gui ./cmd/gtk
 
 
@@ -36,18 +39,19 @@ fpm -s dir -t rpm \
 	-n "aerium-gui" \
 	-v "${VERSION}" \
 	-a "${ARC}" \
+	--depends "aerium-cli = ${VERSION}" \
 	--license "${LICENSE}" \
 	--maintainer "${MAINTAINER}" \
 	--description "${DESC}" \
-	--conflicts aerium-cli \
-	--replaces aerium-cli \
-	--provides aerium-cli \
 	--url "${URL}" \
 	--category "${CATEGORY}" \
 	--rpm-os linux \
+	"${BUILD_DIR}/aerium-daemon"=/usr/local/bin/aerium-daemon \
+	"${BUILD_DIR}/aerium-shell"=/usr/local/bin/aerium-shell \
+	"${BUILD_DIR}/aerium-wallet"=/usr/local/bin/aerium-wallet \
 	"${BUILD_DIR}/aerium-gui"=/usr/local/bin/aerium-gui \
 	"${ROOT_DIR}/.github/releasers/linux/aerium-gui.desktop"=/usr/share/applications/aerium-gui.desktop \
-	"${ROOT_DIR}/cmd/gtk/assets/images/logo.png"=/usr/share/icons/hicolor/256x256/apps/aerium.png
+	${ROOT_DIR}/cmd/gtk/assets/images/logo.png"=/usr/share/icons/hicolor/256x256/apps/aerium.png
 
 echo "RPM package built successfully for ${ARC} architecture"
 

--- a/.github/releasers/releaser_gui_centos.sh
+++ b/.github/releasers/releaser_gui_centos.sh
@@ -3,7 +3,7 @@
 set -e
 
 ROOT_DIR="$(pwd)"
-VERSION="$(echo `git -C ${ROOT_DIR} describe --abbrev=0 --tags` | sed 's/^.//')" # "v1.2.3" -> "1.2.3"
+VERSION="$(git -C ${ROOT_DIR} describe --abbrev=0 --tags | sed 's/^v//')" # "v1.2.3" -> "1.2.3"
 BUILD_DIR="${ROOT_DIR}/build"
 PACKAGE_NAME="aerium-gui_${VERSION}"
 PACKAGE_DIR="${ROOT_DIR}/${PACKAGE_NAME}"
@@ -13,11 +13,11 @@ PACKAGE_DIR="${ROOT_DIR}/${PACKAGE_NAME}"
 MAINTAINER="Aerium Developers <info@aerium.network>"
 LICENSE="MIT"
 DESC="Aerium Desktop Wallet (GUI + CLI components)"
-URL=$(echo `git remote show origin | grep "Fetch URL"` | awk '{printf $3}')
+URL=$(git remote get-url origin)
 CATEGORY="User Interface/Desktops"
 
 # Check the architecture
-ARC="aarch64"
+ARC="$(uname -m)"
 
 mkdir -p ${PACKAGE_DIR}
 
@@ -51,7 +51,7 @@ fpm -s dir -t rpm \
 	"${BUILD_DIR}/aerium-wallet"=/usr/local/bin/aerium-wallet \
 	"${BUILD_DIR}/aerium-gui"=/usr/local/bin/aerium-gui \
 	"${ROOT_DIR}/.github/releasers/linux/aerium-gui.desktop"=/usr/share/applications/aerium-gui.desktop \
-	${ROOT_DIR}/cmd/gtk/assets/images/logo.png"=/usr/share/icons/hicolor/256x256/apps/aerium.png
+	"${ROOT_DIR}/cmd/gtk/assets/images/logo.png"=/usr/share/icons/hicolor/256x256/apps/aerium.png
 
 echo "RPM package built successfully for ${ARC} architecture"
 

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Upload checksum artifact
         uses: actions/upload-artifact@v4
         with:
-          name: checksum-${{ matrix.name }}
+          name: checksum-cli-${{ matrix.name }}
           path: checksum-${{ matrix.name }}.txt
 
       - name: Publish
@@ -90,6 +90,99 @@ jobs:
           files: |
             aerium-gui*.tar.gz
             aerium-gui*.AppImage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  ########################################
+  build-gui-rpm:
+    needs: build-cli-rpm
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        name: [linux-amd64, linux-arm64]
+        include:
+          - name: linux-amd64
+            runner: ubuntu-24.04
+          - name: linux-arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Dependencies
+        run: |
+          sudo apt update
+          sudo apt install libgtk-3-dev libcairo2-dev libglib2.0-dev libfuse2 pkg-config dpkg dpkg-dev ruby ruby-dev build-essential
+          sudo gem install --no-document fpm
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.1"
+
+      - name: Create release files
+        run: bash ./.github/releasers/releaser_gui_centos.sh
+
+      - name: Calculate sha256sum
+        run: sha256sum aerium-gui*.rpm > checksum-${{ matrix.name }}.txt
+
+      - name: Upload checksum artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: checksum-gui-${{ matrix.name }}
+          path: checksum-${{ matrix.name }}.txt
+
+      - name: Publish
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            aerium-gui*.rpm
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  ########################################
+  build-cli-rpm:
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        name: [linux-amd64, linux-arm64]
+        include:
+          - name: linux-amd64
+            runner: ubuntu-24.04
+          - name: linux-arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Dependencies
+        run: |
+          sudo apt update
+          sudo apt install libgtk-3-dev libcairo2-dev libglib2.0-dev libfuse2 pkg-config dpkg dpkg-dev ruby ruby-dev build-essential
+          sudo gem install --no-document fpm
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.1"
+
+      - name: Create release files
+        run: bash ./.github/releasers/releaser_cli_centos.sh
+
+      - name: Calculate sha256sum
+        run: sha256sum aerium-cli*.rpm > checksum-${{ matrix.name }}.txt
+
+      - name: Upload checksum artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: checksum-${{ matrix.name }}
+          path: checksum-${{ matrix.name }}.txt
+
+      - name: Publish
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            aerium-cli*.rpm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Upload checksum artifact
         uses: actions/upload-artifact@v4
         with:
-          name: checksum-cli-${{ matrix.name }}
+          name: checksum-gui-${{ matrix.name }}
           path: checksum-${{ matrix.name }}.txt
 
       - name: Publish
@@ -175,7 +175,7 @@ jobs:
       - name: Upload checksum artifact
         uses: actions/upload-artifact@v4
         with:
-          name: checksum-${{ matrix.name }}
+          name: checksum-cli-${{ matrix.name }}
           path: checksum-${{ matrix.name }}.txt
 
       - name: Publish


### PR DESCRIPTION
## Description

Create a workflow to create RPM packages for both GUI and CLI in amd64 and aarch64 architectures using FPM packager

## Related Issue

Fixes #21 

## Note

aerium-gui-*.rpm makes aerium-cli-*.rpm obsolete since it has all of its binaries 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated CentOS RPM packaging for both CLI and GUI via new release packaging scripts.
  * Extended CI to build RPMs for multiple architectures (amd64, arm64) and produce corresponding checksum artifacts.
  * Enhanced release flow to publish RPM artifacts and their checksums alongside existing distributions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->